### PR TITLE
Update TrackShape.h

### DIFF
--- a/TrackShape.h
+++ b/TrackShape.h
@@ -22,7 +22,7 @@ public:
         int n = 0;
         float pos[3];
         float rotDeg = 0;
-        unsigned short sect[12];
+        unsigned int sect[12];
     };
     
     QString filename;


### PR DESCRIPTION
This corrects the TDB limit of 65535 vectors when this was set from an integer to a short value.  